### PR TITLE
增加enabled参数

### DIFF
--- a/js/scratchcard.js
+++ b/js/scratchcard.js
@@ -8,6 +8,7 @@
 	// Constructor of scratch card
 	function ScratchCard(options){
 		this.options = options;
+		this.enabled = true;
 		this.scratchActivated = false;
 		this.extendOptions();
 		this.initialize();
@@ -27,7 +28,7 @@
 		return clonedObj;
 	}
 
-	// Extend origin object with default options object 
+	// Extend origin object with default options object
 	function extend(origin, options){
 		var extendedOpt = clone(options);
 			origin = origin || {};
@@ -67,7 +68,7 @@
 		} else if(document.attachEvent){
 			elem.attachEvent('on' + eventName, callback);
 		} else {
-			elem['on' + eventName] = callback; 
+			elem['on' + eventName] = callback;
 		}
 	}
 
@@ -77,7 +78,7 @@
 		} else if(document.detachEvent){
 			elem.detachEvent('on' + eventName, callback);
 		} else {
-			elem['on' + eventName] = null; 
+			elem['on' + eventName] = null;
 		}
 	}
 
@@ -309,7 +310,7 @@
 
 			ctx.globalCompositeOperation = "source-over";
 
-			// Paint canvas to gray 
+			// Paint canvas to gray
 			ctx.fillStyle = scratchLayer.background;
 			ctx.fillRect(0, 0, canvas.width, canvas.height);
 
@@ -324,7 +325,7 @@
 			ctx.strokeStyle = 'rgba(255, 255, 255, 1)';
 			ctx.lineJoin = 'round';
 			ctx.lineCap = 'round';
-			ctx.lineWidth = scratchLayer.lineWidth; 
+			ctx.lineWidth = scratchLayer.lineWidth;
 		},
 
 		bindEvents: function(){
@@ -359,7 +360,7 @@
 		},
 
 		mousemoveHandler: function(e){
-			if(!this.scratchActivated) return;
+			if(!this.enabled || !this.scratchActivated) return;
 
 			var ctx = this.ctx,
 				canvas = this.canvas,
@@ -383,7 +384,7 @@
 
 			this.scratchActivated = false;
 			ctx.closePath();
-			onScratch && onScratch(this.getScratchedPercentage());		
+			onScratch && onScratch(this.getScratchedPercentage());
 			this.isOktoShowAll(this.getScratchedPercentage());
 		},
 


### PR DESCRIPTION
就增加了一个enabled参数。

大多数情况下，抽奖的逻辑是页面初始化后发异步请求。或者那种页面可以反复抽奖的场景。
所以在请求没回来之前，刮刮卡是不能刮的。所以加了这个参数，默认是true，可以手动设置为false。
临时需求我就自己先加了一下。

对于上述的场景，应该还有一些方法可以开出来。

例如：
开始的时候可以不传图片；（现在会报错）；
中途可以替换下面的内容；（我用$(card.img).attr("src",*)）
canvas的reset方法；（我用card.initCanvas();替换）
